### PR TITLE
updated dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "hauler-docs",
-  "version": "1.0.x",
+  "version": "1.1.x",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hauler-docs",
-      "version": "1.0.x",
+      "version": "1.1.x",
       "dependencies": {
-        "@docusaurus/core": "^3.6.1",
-        "@docusaurus/preset-classic": "^3.6.1",
+        "@docusaurus/core": "^3.7.0",
+        "@docusaurus/preset-classic": "^3.7.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.1.0",
         "docusaurus-lunr-search": "^3.3.2",
@@ -18,42 +18,42 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.6.1",
-        "@docusaurus/types": "^3.6.1"
+        "@docusaurus/module-type-aliases": "^3.7.0",
+        "@docusaurus/types": "^3.7.0"
       },
       "engines": {
         "node": ">=18.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
-      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.9.tgz",
+      "integrity": "sha512-O7BxrpLDPJWWHv/DLA9DRFWs+iY1uOJZkqUwjS5HSZAGcl0hIVCQ97LTLewiZmZ402JYUrun+8NqFP+hCknlbQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
-        "@algolia/autocomplete-shared": "1.17.7"
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.9",
+        "@algolia/autocomplete-shared": "1.17.9"
       }
     },
     "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
-      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.9.tgz",
+      "integrity": "sha512-u1fEHkCbWF92DBeB/KHeMacsjsoI0wFhjZtlCq2ddZbAehshbZST6Hs0Avkc0s+4UyBGbMDnSuXHLuvRWK5iDQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.17.7"
+        "@algolia/autocomplete-shared": "1.17.9"
       },
       "peerDependencies": {
         "search-insights": ">= 1 < 3"
       }
     },
     "node_modules/@algolia/autocomplete-preset-algolia": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
-      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.9.tgz",
+      "integrity": "sha512-Na1OuceSJeg8j7ZWn5ssMu/Ax3amtOwk76u4h5J4eK2Nx2KB5qt0Z4cOapCsxot9VcEN11ADV5aUSlQF4RhGjQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.17.7"
+        "@algolia/autocomplete-shared": "1.17.9"
       },
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
@@ -61,189 +61,109 @@
       }
     },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
-      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.9.tgz",
+      "integrity": "sha512-iDf05JDQ7I0b7JEA/9IektxN/80a2MZ1ToohfmNS3rfeuQnIKI3IJlIafD0xu4StbtQTghx9T3Maa97ytkXenQ==",
       "license": "MIT",
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
         "algoliasearch": ">= 4.9.1 < 6"
       }
     },
-    "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.24.0.tgz",
-      "integrity": "sha512-t63W9BnoXVrGy9iYHBgObNXqYXM3tYXCjDSHeNwnsc324r4o5UiVKUiAB4THQ5z9U5hTj6qUvwg/Ez43ZD85ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/cache-common": "4.24.0"
-      }
-    },
-    "node_modules/@algolia/cache-common": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.24.0.tgz",
-      "integrity": "sha512-emi+v+DmVLpMGhp0V9q9h5CdkURsNmFC+cOS6uK9ndeJm9J4TiqSvPYVu+THUP8P/S08rxf5x2P+p3CfID0Y4g==",
-      "license": "MIT"
-    },
-    "node_modules/@algolia/cache-in-memory": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.24.0.tgz",
-      "integrity": "sha512-gDrt2so19jW26jY3/MkFg5mEypFIPbPoXsQGQWAi6TrCPsNOSEYepBMPlucqWigsmEy/prp5ug2jy/N3PVG/8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/cache-common": "4.24.0"
-      }
-    },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.17.1.tgz",
-      "integrity": "sha512-Os/xkQbDp5A5RdGYq1yS3fF69GoBJH5FIfrkVh+fXxCSe714i1Xdl9XoXhS4xG76DGKm6EFMlUqP024qjps8cg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.20.0.tgz",
+      "integrity": "sha512-YaEoNc1Xf2Yk6oCfXXkZ4+dIPLulCx8Ivqj0OsdkHWnsI3aOJChY5qsfyHhDBNSOhqn2ilgHWxSfyZrjxBcAww==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.17.1",
-        "@algolia/requester-browser-xhr": "5.17.1",
-        "@algolia/requester-fetch": "5.17.1",
-        "@algolia/requester-node-http": "5.17.1"
+        "@algolia/client-common": "5.20.0",
+        "@algolia/requester-browser-xhr": "5.20.0",
+        "@algolia/requester-fetch": "5.20.0",
+        "@algolia/requester-node-http": "5.20.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/@algolia/client-account": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.24.0.tgz",
-      "integrity": "sha512-adcvyJ3KjPZFDybxlqnf+5KgxJtBjwTPTeyG2aOyoJvx0Y8dUQAEOEVOJ/GBxX0WWNbmaSrhDURMhc+QeevDsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "4.24.0",
-        "@algolia/client-search": "4.24.0",
-        "@algolia/transporter": "4.24.0"
-      }
-    },
-    "node_modules/@algolia/client-account/node_modules/@algolia/client-common": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
-      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/transporter": "4.24.0"
-      }
-    },
-    "node_modules/@algolia/client-account/node_modules/@algolia/client-search": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
-      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "4.24.0",
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/transporter": "4.24.0"
-      }
-    },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.24.0.tgz",
-      "integrity": "sha512-y8jOZt1OjwWU4N2qr8G4AxXAzaa8DBvyHTWlHzX/7Me1LX8OayfgHexqrsL4vSBcoMmVw2XnVW9MhL+Y2ZDJXg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.20.0.tgz",
+      "integrity": "sha512-CIT9ni0+5sYwqehw+t5cesjho3ugKQjPVy/iPiJvtJX4g8Cdb6je6SPt2uX72cf2ISiXCAX9U3cY0nN0efnRDw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.24.0",
-        "@algolia/client-search": "4.24.0",
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/transporter": "4.24.0"
-      }
-    },
-    "node_modules/@algolia/client-analytics/node_modules/@algolia/client-common": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
-      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/transporter": "4.24.0"
-      }
-    },
-    "node_modules/@algolia/client-analytics/node_modules/@algolia/client-search": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
-      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "4.24.0",
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/transporter": "4.24.0"
+        "@algolia/client-common": "5.20.0",
+        "@algolia/requester-browser-xhr": "5.20.0",
+        "@algolia/requester-fetch": "5.20.0",
+        "@algolia/requester-node-http": "5.20.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.17.1.tgz",
-      "integrity": "sha512-5rb5+yPIie6912riAypTSyzbE23a7UM1UpESvD8GEPI4CcWQvA9DBlkRNx9qbq/nJ5pvv8VjZjUxJj7rFkzEAA==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.20.0.tgz",
+      "integrity": "sha512-iSTFT3IU8KNpbAHcBUJw2HUrPnMXeXLyGajmCL7gIzWOsYM4GabZDHXOFx93WGiXMti1dymz8k8R+bfHv1YZmA==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.17.1.tgz",
-      "integrity": "sha512-nb/tfwBMn209TzFv1DDTprBKt/wl5btHVKoAww9fdEVdoKK02R2KAqxe5tuXLdEzAsS+LevRyOM/YjXuLmPtjQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.20.0.tgz",
+      "integrity": "sha512-w9RIojD45z1csvW1vZmAko82fqE/Dm+Ovsy2ElTsjFDB0HMAiLh2FO86hMHbEXDPz6GhHKgGNmBRiRP8dDPgJg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.17.1",
-        "@algolia/requester-browser-xhr": "5.17.1",
-        "@algolia/requester-fetch": "5.17.1",
-        "@algolia/requester-node-http": "5.17.1"
+        "@algolia/client-common": "5.20.0",
+        "@algolia/requester-browser-xhr": "5.20.0",
+        "@algolia/requester-fetch": "5.20.0",
+        "@algolia/requester-node-http": "5.20.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.24.0.tgz",
-      "integrity": "sha512-l5FRFm/yngztweU0HdUzz1rC4yoWCFo3IF+dVIVTfEPg906eZg5BOd1k0K6rZx5JzyyoP4LdmOikfkfGsKVE9w==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.20.0.tgz",
+      "integrity": "sha512-p/hftHhrbiHaEcxubYOzqVV4gUqYWLpTwK+nl2xN3eTrSW9SNuFlAvUBFqPXSVBqc6J5XL9dNKn3y8OA1KElSQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.24.0",
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/transporter": "4.24.0"
-      }
-    },
-    "node_modules/@algolia/client-personalization/node_modules/@algolia/client-common": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
-      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/transporter": "4.24.0"
+        "@algolia/client-common": "5.20.0",
+        "@algolia/requester-browser-xhr": "5.20.0",
+        "@algolia/requester-fetch": "5.20.0",
+        "@algolia/requester-node-http": "5.20.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.17.1.tgz",
-      "integrity": "sha512-RBIFIv1QE3IlAikJKWTOpd6pwE4d2dY6t02iXH7r/SLXWn0HzJtsAPPeFg/OKkFvWAXt0H7In2/Mp7a1/Dy2pw==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.20.0.tgz",
+      "integrity": "sha512-m4aAuis5vZi7P4gTfiEs6YPrk/9hNTESj3gEmGFgfJw3hO2ubdS4jSId1URd6dGdt0ax2QuapXufcrN58hPUcw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.17.1",
-        "@algolia/requester-browser-xhr": "5.17.1",
-        "@algolia/requester-fetch": "5.17.1",
-        "@algolia/requester-node-http": "5.17.1"
+        "@algolia/client-common": "5.20.0",
+        "@algolia/requester-browser-xhr": "5.20.0",
+        "@algolia/requester-fetch": "5.20.0",
+        "@algolia/requester-node-http": "5.20.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.17.1.tgz",
-      "integrity": "sha512-bd5JBUOP71kPsxwDcvOxqtqXXVo/706NFifZ/O5Rx5GB8ZNVAhg4l7aGoT6jBvEfgmrp2fqPbkdIZ6JnuOpGcw==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.20.0.tgz",
+      "integrity": "sha512-KL1zWTzrlN4MSiaK1ea560iCA/UewMbS4ZsLQRPoDTWyrbDKVbztkPwwv764LAqgXk0fvkNZvJ3IelcK7DqhjQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.17.1",
-        "@algolia/requester-browser-xhr": "5.17.1",
-        "@algolia/requester-fetch": "5.17.1",
-        "@algolia/requester-node-http": "5.17.1"
+        "@algolia/client-common": "5.20.0",
+        "@algolia/requester-browser-xhr": "5.20.0",
+        "@algolia/requester-fetch": "5.20.0",
+        "@algolia/requester-node-http": "5.20.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -256,159 +176,84 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.17.1.tgz",
-      "integrity": "sha512-T18tvePi1rjRYcIKhd82oRukrPWHxG/Iy1qFGaxCplgRm9Im5z96qnYOq75MSKGOUHkFxaBKJOLmtn8xDR+Mcw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.20.0.tgz",
+      "integrity": "sha512-shj2lTdzl9un4XJblrgqg54DoK6JeKFO8K8qInMu4XhE2JuB8De6PUuXAQwiRigZupbI0xq8aM0LKdc9+qiLQA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.17.1",
-        "@algolia/requester-browser-xhr": "5.17.1",
-        "@algolia/requester-fetch": "5.17.1",
-        "@algolia/requester-node-http": "5.17.1"
+        "@algolia/client-common": "5.20.0",
+        "@algolia/requester-browser-xhr": "5.20.0",
+        "@algolia/requester-fetch": "5.20.0",
+        "@algolia/requester-node-http": "5.20.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/@algolia/logger-common": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.24.0.tgz",
-      "integrity": "sha512-LLUNjkahj9KtKYrQhFKCzMx0BY3RnNP4FEtO+sBybCjJ73E8jNdaKJ/Dd8A/VA4imVHP5tADZ8pn5B8Ga/wTMA==",
-      "license": "MIT"
-    },
-    "node_modules/@algolia/logger-console": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.24.0.tgz",
-      "integrity": "sha512-X4C8IoHgHfiUROfoRCV+lzSy+LHMgkoEEU1BbKcsfnV0i0S20zyy0NLww9dwVHUWNfPPxdMU+/wKmLGYf96yTg==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/logger-common": "4.24.0"
-      }
-    },
     "node_modules/@algolia/monitoring": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.17.1.tgz",
-      "integrity": "sha512-gDtow+AUywTehRP8S1tWKx2IvhcJOxldAoqBxzN3asuQobF7er5n72auBeL++HY4ImEuzMi7PDOA/Iuwxs2IcA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.20.0.tgz",
+      "integrity": "sha512-aF9blPwOhKtWvkjyyXh9P5peqmhCA1XxLBRgItT+K6pbT0q4hBDQrCid+pQZJYy4HFUKjB/NDDwyzFhj/rwKhw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.17.1",
-        "@algolia/requester-browser-xhr": "5.17.1",
-        "@algolia/requester-fetch": "5.17.1",
-        "@algolia/requester-node-http": "5.17.1"
+        "@algolia/client-common": "5.20.0",
+        "@algolia/requester-browser-xhr": "5.20.0",
+        "@algolia/requester-fetch": "5.20.0",
+        "@algolia/requester-node-http": "5.20.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.24.0.tgz",
-      "integrity": "sha512-P9kcgerfVBpfYHDfVZDvvdJv0lEoCvzNlOy2nykyt5bK8TyieYyiD0lguIJdRZZYGre03WIAFf14pgE+V+IBlw==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.20.0.tgz",
+      "integrity": "sha512-T6B/WPdZR3b89/F9Vvk6QCbt/wrLAtrGoL8z4qPXDFApQ8MuTFWbleN/4rHn6APWO3ps+BUePIEbue2rY5MlRw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.24.0",
-        "@algolia/cache-common": "4.24.0",
-        "@algolia/cache-in-memory": "4.24.0",
-        "@algolia/client-common": "4.24.0",
-        "@algolia/client-search": "4.24.0",
-        "@algolia/logger-common": "4.24.0",
-        "@algolia/logger-console": "4.24.0",
-        "@algolia/requester-browser-xhr": "4.24.0",
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/requester-node-http": "4.24.0",
-        "@algolia/transporter": "4.24.0"
-      }
-    },
-    "node_modules/@algolia/recommend/node_modules/@algolia/client-common": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
-      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/transporter": "4.24.0"
-      }
-    },
-    "node_modules/@algolia/recommend/node_modules/@algolia/client-search": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
-      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "4.24.0",
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/transporter": "4.24.0"
-      }
-    },
-    "node_modules/@algolia/recommend/node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
-      "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.24.0"
-      }
-    },
-    "node_modules/@algolia/recommend/node_modules/@algolia/requester-node-http": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
-      "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.24.0"
-      }
-    },
-    "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.17.1.tgz",
-      "integrity": "sha512-XpKgBfyczVesKgr7DOShNyPPu5kqlboimRRPjdqAw5grSyHhCmb8yoTIKy0TCqBABZeXRPMYT13SMruUVRXvHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.17.1"
+        "@algolia/client-common": "5.20.0",
+        "@algolia/requester-browser-xhr": "5.20.0",
+        "@algolia/requester-fetch": "5.20.0",
+        "@algolia/requester-node-http": "5.20.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/@algolia/requester-common": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.24.0.tgz",
-      "integrity": "sha512-k3CXJ2OVnvgE3HMwcojpvY6d9kgKMPRxs/kVohrwF5WMr2fnqojnycZkxPoEg+bXm8fi5BBfFmOqgYztRtHsQA==",
-      "license": "MIT"
-    },
-    "node_modules/@algolia/requester-fetch": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.17.1.tgz",
-      "integrity": "sha512-EhUomH+DZP5vb6DnEjT0GvXaXBSwzZnuU6hPGNU1EYKRXDouRjII/bIWpVjt7ycMgL2D2oQruqDh6rAWUhQwRw==",
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.20.0.tgz",
+      "integrity": "sha512-t6//lXsq8E85JMenHrI6mhViipUT5riNhEfCcvtRsTV+KIBpC6Od18eK864dmBhoc5MubM0f+sGpKOqJIlBSCg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.17.1"
+        "@algolia/client-common": "5.20.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.20.0.tgz",
+      "integrity": "sha512-FHxYGqRY+6bgjKsK4aUsTAg6xMs2S21elPe4Y50GB0Y041ihvw41Vlwy2QS6K9ldoftX4JvXodbKTcmuQxywdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.20.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.17.1.tgz",
-      "integrity": "sha512-PSnENJtl4/wBWXlGyOODbLYm6lSiFqrtww7UpQRCJdsHXlJKF8XAP6AME8NxvbE0Qo/RJUxK0mvyEh9sQcx6bg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.20.0.tgz",
+      "integrity": "sha512-kmtQClq/w3vtPteDSPvaW9SPZL/xrIgMrxZyAgsFwrJk0vJxqyC5/hwHmrCraDnStnGSADnLpBf4SpZnwnkwWw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.17.1"
+        "@algolia/client-common": "5.20.0"
       },
       "engines": {
         "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/transporter": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.24.0.tgz",
-      "integrity": "sha512-86nI7w6NzWxd1Zp9q3413dRshDqAzSbsQjhcDhPIatEFiZrL1/TjnHL8S7jVKFePlIMzDsZWXAXwXzcok9c5oA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/cache-common": "4.24.0",
-        "@algolia/logger-common": "4.24.0",
-        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -439,30 +284,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
-      "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
+      "integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
-      "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.7.tgz",
+      "integrity": "sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==",
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.26.0",
-        "@babel/generator": "^7.26.0",
-        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.5",
+        "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.0",
-        "@babel/parser": "^7.26.0",
+        "@babel/helpers": "^7.26.7",
+        "@babel/parser": "^7.26.7",
         "@babel/template": "^7.25.9",
-        "@babel/traverse": "^7.25.9",
-        "@babel/types": "^7.26.0",
+        "@babel/traverse": "^7.26.7",
+        "@babel/types": "^7.26.7",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -487,13 +332,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
-      "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+      "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.3",
-        "@babel/types": "^7.26.3",
+        "@babel/parser": "^7.26.5",
+        "@babel/types": "^7.26.5",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -515,12 +360,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
-      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
+      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.25.9",
+        "@babel/compat-data": "^7.26.5",
         "@babel/helper-validator-option": "^7.25.9",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -667,9 +512,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
-      "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -693,14 +538,14 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
-      "integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz",
+      "integrity": "sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.25.9",
         "@babel/helper-optimise-call-expression": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/traverse": "^7.26.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -764,25 +609,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.7.tgz",
+      "integrity": "sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==",
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.0"
+        "@babel/types": "^7.26.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
-      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
+      "integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.3"
+        "@babel/types": "^7.26.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1020,12 +865,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.25.9.tgz",
-      "integrity": "sha512-toHc9fzab0ZfenFpsyYinOX0J/5dgJVA2fm64xPewu7CoYHWEivIWKxkK2rMi4r3yQqLnVmheMXRdG+k239CgA==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.26.5.tgz",
+      "integrity": "sha512-chuTSY+hq09+/f5lMj8ZSYgCFpppV2CbYrhNFJ1BFoXpiWPnnAb7R0MqrafCpN8E1+YRrtM1MXZHJdIx8B6rMQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.26.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1415,12 +1260,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.9.tgz",
-      "integrity": "sha512-ENfftpLZw5EItALAD4WsY/KUWvhUlZndm5GC7G3evUsVeSJB6p0pBeLQUnRnBCBx7zV0RKQjR9kCuwrsIrjWog==",
+      "version": "7.26.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz",
+      "integrity": "sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.26.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1789,12 +1634,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.25.9.tgz",
-      "integrity": "sha512-v61XqUMiueJROUv66BVIOi0Fv/CUuZuZMl5NkRoCVxLAnMexZ0A3kMe7vvZ0nulxMuMp0Mk6S5hNh48yki08ZA==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.26.7.tgz",
+      "integrity": "sha512-jfoTXXZTgGg36BmhqT3cAYK5qkmqvJpvNrPhaK/52Vgjhw4Rq29s9UqpWWV0D6yuRmgiFH/BUVlkl96zJWqnaw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.26.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1804,14 +1649,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.3.tgz",
-      "integrity": "sha512-6+5hpdr6mETwSKjmJUdYw0EIkATiQhnELWlE3kJFBwSg/BGIVwVaVbX+gOXBCdc7Ln1RXZxyWGecIXhUfnl7oA==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.7.tgz",
+      "integrity": "sha512-5cJurntg+AT+cgelGP9Bt788DKiAw9gIMSMU2NJrLAilnj0m8WZWUNZPSLOmadYsujHutpgElO+50foX+ib/Wg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-create-class-features-plugin": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9"
       },
@@ -1886,14 +1731,14 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.0.tgz",
-      "integrity": "sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.7.tgz",
+      "integrity": "sha512-Ycg2tnXwixaXOVb29rana8HNPgLVBof8qqtNQ9LE22IoyZboQbGSxI6ZySMdW3K5nAe6gu35IaJefUJflhUFTQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.26.0",
-        "@babel/helper-compilation-targets": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/compat-data": "^7.26.5",
+        "@babel/helper-compilation-targets": "^7.26.5",
+        "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-validator-option": "^7.25.9",
         "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.9",
         "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.9",
@@ -1907,7 +1752,7 @@
         "@babel/plugin-transform-arrow-functions": "^7.25.9",
         "@babel/plugin-transform-async-generator-functions": "^7.25.9",
         "@babel/plugin-transform-async-to-generator": "^7.25.9",
-        "@babel/plugin-transform-block-scoped-functions": "^7.25.9",
+        "@babel/plugin-transform-block-scoped-functions": "^7.26.5",
         "@babel/plugin-transform-block-scoping": "^7.25.9",
         "@babel/plugin-transform-class-properties": "^7.25.9",
         "@babel/plugin-transform-class-static-block": "^7.26.0",
@@ -1918,7 +1763,7 @@
         "@babel/plugin-transform-duplicate-keys": "^7.25.9",
         "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.9",
         "@babel/plugin-transform-dynamic-import": "^7.25.9",
-        "@babel/plugin-transform-exponentiation-operator": "^7.25.9",
+        "@babel/plugin-transform-exponentiation-operator": "^7.26.3",
         "@babel/plugin-transform-export-namespace-from": "^7.25.9",
         "@babel/plugin-transform-for-of": "^7.25.9",
         "@babel/plugin-transform-function-name": "^7.25.9",
@@ -1927,12 +1772,12 @@
         "@babel/plugin-transform-logical-assignment-operators": "^7.25.9",
         "@babel/plugin-transform-member-expression-literals": "^7.25.9",
         "@babel/plugin-transform-modules-amd": "^7.25.9",
-        "@babel/plugin-transform-modules-commonjs": "^7.25.9",
+        "@babel/plugin-transform-modules-commonjs": "^7.26.3",
         "@babel/plugin-transform-modules-systemjs": "^7.25.9",
         "@babel/plugin-transform-modules-umd": "^7.25.9",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.25.9",
         "@babel/plugin-transform-new-target": "^7.25.9",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.25.9",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.26.6",
         "@babel/plugin-transform-numeric-separator": "^7.25.9",
         "@babel/plugin-transform-object-rest-spread": "^7.25.9",
         "@babel/plugin-transform-object-super": "^7.25.9",
@@ -1949,7 +1794,7 @@
         "@babel/plugin-transform-spread": "^7.25.9",
         "@babel/plugin-transform-sticky-regex": "^7.25.9",
         "@babel/plugin-transform-template-literals": "^7.25.9",
-        "@babel/plugin-transform-typeof-symbol": "^7.25.9",
+        "@babel/plugin-transform-typeof-symbol": "^7.26.7",
         "@babel/plugin-transform-unicode-escapes": "^7.25.9",
         "@babel/plugin-transform-unicode-property-regex": "^7.25.9",
         "@babel/plugin-transform-unicode-regex": "^7.25.9",
@@ -2031,9 +1876,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
+      "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -2043,9 +1888,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.26.0.tgz",
-      "integrity": "sha512-YXHu5lN8kJCb1LOb9PgV6pvak43X2h4HvRApcN5SdWeaItQOzfn1hgP6jasD6KWQyJDBxrVmA9o9OivlnNJK/w==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.26.7.tgz",
+      "integrity": "sha512-55gRV8vGrCIYZnaQHQrD92Lo/hYE3Sj5tmbuf0hhHR7sj2CWhEhHU89hbq+UVDXvFG1zUVXJhUkEq1eAfqXtFw==",
       "license": "MIT",
       "dependencies": {
         "core-js-pure": "^3.30.2",
@@ -2070,16 +1915,16 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
-      "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.7.tgz",
+      "integrity": "sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.3",
-        "@babel/parser": "^7.26.3",
+        "@babel/generator": "^7.26.5",
+        "@babel/parser": "^7.26.7",
         "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.3",
+        "@babel/types": "^7.26.7",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -2088,9 +1933,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
-      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
+      "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
@@ -2153,9 +1998,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.0.tgz",
-      "integrity": "sha512-X69PmFOrjTZfN5ijxtI8hZ9kRADFSLrmmQ6hgDJ272Il049WGKpDY64KhrFm/7rbWve0z81QepawzjkKlqkNGw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.1.tgz",
+      "integrity": "sha512-rL7kaUnTkL9K+Cvo2pnCieqNpTKgQzy5f+N+5Iuko9HAoasP+xgprVh7KN/MaJVvVL1l0EzQq2MoqBHKSrDrag==",
       "funding": [
         {
           "type": "github",
@@ -2176,9 +2021,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.6.tgz",
-      "integrity": "sha512-S/IjXqTHdpI4EtzGoNCHfqraXF37x12ZZHA1Lk7zoT5pm2lMjFuqhX/89L7dqX4CcMacKK+6ZCs5TmEGb/+wKw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.7.tgz",
+      "integrity": "sha512-nkMp2mTICw32uE5NN+EsJ4f5N+IGFeCFu4bGpiKgb2Pq/7J/MpyLBeQ5ry4KKtRFZaYs6sTmcMYrSRIyj5DFKA==",
       "funding": [
         {
           "type": "github",
@@ -2192,7 +2037,7 @@
       "license": "MIT",
       "dependencies": {
         "@csstools/color-helpers": "^5.0.1",
-        "@csstools/css-calc": "^2.1.0"
+        "@csstools/css-calc": "^2.1.1"
       },
       "engines": {
         "node": ">=18"
@@ -2328,9 +2173,9 @@
       }
     },
     "node_modules/@csstools/postcss-color-function": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-4.0.6.tgz",
-      "integrity": "sha512-EcvXfC60cTIumzpsxWuvVjb7rsJEHPvqn3jeMEBUaE3JSc4FRuP7mEQ+1eicxWmIrs3FtzMH9gR3sgA5TH+ebQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-4.0.7.tgz",
+      "integrity": "sha512-aDHYmhNIHR6iLw4ElWhf+tRqqaXwKnMl0YsQ/X105Zc4dQwe6yJpMrTN6BwOoESrkDjOYMOfORviSSLeDTJkdQ==",
       "funding": [
         {
           "type": "github",
@@ -2343,7 +2188,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.6",
+        "@csstools/css-color-parser": "^3.0.7",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "@csstools/postcss-progressive-custom-properties": "^4.0.0",
@@ -2357,9 +2202,9 @@
       }
     },
     "node_modules/@csstools/postcss-color-mix-function": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-function/-/postcss-color-mix-function-3.0.6.tgz",
-      "integrity": "sha512-jVKdJn4+JkASYGhyPO+Wa5WXSx1+oUgaXb3JsjJn/BlrtFh5zjocCY7pwWi0nuP24V1fY7glQsxEYcYNy0dMFg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-function/-/postcss-color-mix-function-3.0.7.tgz",
+      "integrity": "sha512-e68Nev4CxZYCLcrfWhHH4u/N1YocOfTmw67/kVX5Rb7rnguqqLyxPjhHWjSBX8o4bmyuukmNf3wrUSU3//kT7g==",
       "funding": [
         {
           "type": "github",
@@ -2372,7 +2217,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.6",
+        "@csstools/css-color-parser": "^3.0.7",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "@csstools/postcss-progressive-custom-properties": "^4.0.0",
@@ -2414,9 +2259,9 @@
       }
     },
     "node_modules/@csstools/postcss-exponential-functions": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-exponential-functions/-/postcss-exponential-functions-2.0.5.tgz",
-      "integrity": "sha512-mi8R6dVfA2nDoKM3wcEi64I8vOYEgQVtVKCfmLHXupeLpACfGAided5ddMt5f+CnEodNu4DifuVwb0I6fQDGGQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-exponential-functions/-/postcss-exponential-functions-2.0.6.tgz",
+      "integrity": "sha512-IgJA5DQsQLu/upA3HcdvC6xEMR051ufebBTIXZ5E9/9iiaA7juXWz1ceYj814lnDYP/7eWjZnw0grRJlX4eI6g==",
       "funding": [
         {
           "type": "github",
@@ -2429,7 +2274,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.0",
+        "@csstools/css-calc": "^2.1.1",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3"
       },
@@ -2467,9 +2312,9 @@
       }
     },
     "node_modules/@csstools/postcss-gamut-mapping": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-gamut-mapping/-/postcss-gamut-mapping-2.0.6.tgz",
-      "integrity": "sha512-0ke7fmXfc8H+kysZz246yjirAH6JFhyX9GTlyRnM0exHO80XcA9zeJpy5pOp5zo/AZiC/q5Pf+Hw7Pd6/uAoYA==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-gamut-mapping/-/postcss-gamut-mapping-2.0.7.tgz",
+      "integrity": "sha512-gzFEZPoOkY0HqGdyeBXR3JP218Owr683u7KOZazTK7tQZBE8s2yhg06W1tshOqk7R7SWvw9gkw2TQogKpIW8Xw==",
       "funding": [
         {
           "type": "github",
@@ -2482,7 +2327,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.6",
+        "@csstools/css-color-parser": "^3.0.7",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3"
       },
@@ -2494,9 +2339,9 @@
       }
     },
     "node_modules/@csstools/postcss-gradients-interpolation-method": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-gradients-interpolation-method/-/postcss-gradients-interpolation-method-5.0.6.tgz",
-      "integrity": "sha512-Itrbx6SLUzsZ6Mz3VuOlxhbfuyLTogG5DwEF1V8dAi24iMuvQPIHd7Ti+pNDp7j6WixndJGZaoNR0f9VSzwuTg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-gradients-interpolation-method/-/postcss-gradients-interpolation-method-5.0.7.tgz",
+      "integrity": "sha512-WgEyBeg6glUeTdS2XT7qeTFBthTJuXlS9GFro/DVomj7W7WMTamAwpoP4oQCq/0Ki2gvfRYFi/uZtmRE14/DFA==",
       "funding": [
         {
           "type": "github",
@@ -2509,7 +2354,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.6",
+        "@csstools/css-color-parser": "^3.0.7",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "@csstools/postcss-progressive-custom-properties": "^4.0.0",
@@ -2523,9 +2368,9 @@
       }
     },
     "node_modules/@csstools/postcss-hwb-function": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-4.0.6.tgz",
-      "integrity": "sha512-927Pqy3a1uBP7U8sTfaNdZVB0mNXzIrJO/GZ8us9219q9n06gOqCdfZ0E6d1P66Fm0fYHvxfDbfcUuwAn5UwhQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-4.0.7.tgz",
+      "integrity": "sha512-LKYqjO+wGwDCfNIEllessCBWfR4MS/sS1WXO+j00KKyOjm7jDW2L6jzUmqASEiv/kkJO39GcoIOvTTfB3yeBUA==",
       "funding": [
         {
           "type": "github",
@@ -2538,7 +2383,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.6",
+        "@csstools/css-color-parser": "^3.0.7",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "@csstools/postcss-progressive-custom-properties": "^4.0.0",
@@ -2807,9 +2652,9 @@
       }
     },
     "node_modules/@csstools/postcss-media-minmax": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-media-minmax/-/postcss-media-minmax-2.0.5.tgz",
-      "integrity": "sha512-sdh5i5GToZOIAiwhdntRWv77QDtsxP2r2gXW/WbLSCoLr00KTq/yiF1qlQ5XX2+lmiFa8rATKMcbwl3oXDMNew==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-media-minmax/-/postcss-media-minmax-2.0.6.tgz",
+      "integrity": "sha512-J1+4Fr2W3pLZsfxkFazK+9kr96LhEYqoeBszLmFjb6AjYs+g9oDAw3J5oQignLKk3rC9XHW+ebPTZ9FaW5u5pg==",
       "funding": [
         {
           "type": "github",
@@ -2822,7 +2667,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.0",
+        "@csstools/css-calc": "^2.1.1",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "@csstools/media-query-list-parser": "^4.0.2"
@@ -2913,9 +2758,9 @@
       }
     },
     "node_modules/@csstools/postcss-oklab-function": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-4.0.6.tgz",
-      "integrity": "sha512-Hptoa0uX+XsNacFBCIQKTUBrFKDiplHan42X73EklG6XmQLG7/aIvxoNhvZ7PvOWMt67Pw3bIlUY2nD6p5vL8A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-4.0.7.tgz",
+      "integrity": "sha512-I6WFQIbEKG2IO3vhaMGZDkucbCaUSXMxvHNzDdnfsTCF5tc0UlV3Oe2AhamatQoKFjBi75dSEMrgWq3+RegsOQ==",
       "funding": [
         {
           "type": "github",
@@ -2928,7 +2773,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.6",
+        "@csstools/css-color-parser": "^3.0.7",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "@csstools/postcss-progressive-custom-properties": "^4.0.0",
@@ -2967,9 +2812,9 @@
       }
     },
     "node_modules/@csstools/postcss-random-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-random-function/-/postcss-random-function-1.0.1.tgz",
-      "integrity": "sha512-Ab/tF8/RXktQlFwVhiC70UNfpFQRhtE5fQQoP2pO+KCPGLsLdWFiOuHgSRtBOqEshCVAzR4H6o38nhvRZq8deA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-random-function/-/postcss-random-function-1.0.2.tgz",
+      "integrity": "sha512-vBCT6JvgdEkvRc91NFoNrLjgGtkLWt47GKT6E2UDn3nd8ZkMBiziQ1Md1OiKoSsgzxsSnGKG3RVdhlbdZEkHjA==",
       "funding": [
         {
           "type": "github",
@@ -2982,7 +2827,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.0",
+        "@csstools/css-calc": "^2.1.1",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3"
       },
@@ -2994,9 +2839,9 @@
       }
     },
     "node_modules/@csstools/postcss-relative-color-syntax": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-relative-color-syntax/-/postcss-relative-color-syntax-3.0.6.tgz",
-      "integrity": "sha512-yxP618Xb+ji1I624jILaYM62uEmZcmbdmFoZHoaThw896sq0vU39kqTTF+ZNic9XyPtPMvq0vyvbgmHaszq8xg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-relative-color-syntax/-/postcss-relative-color-syntax-3.0.7.tgz",
+      "integrity": "sha512-apbT31vsJVd18MabfPOnE977xgct5B1I+Jpf+Munw3n6kKb1MMuUmGGH+PT9Hm/fFs6fe61Q/EWnkrb4bNoNQw==",
       "funding": [
         {
           "type": "github",
@@ -3009,7 +2854,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.6",
+        "@csstools/css-color-parser": "^3.0.7",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "@csstools/postcss-progressive-custom-properties": "^4.0.0",
@@ -3061,9 +2906,9 @@
       }
     },
     "node_modules/@csstools/postcss-sign-functions": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-sign-functions/-/postcss-sign-functions-1.1.0.tgz",
-      "integrity": "sha512-SLcc20Nujx/kqbSwDmj6oaXgpy3UjFhBy1sfcqPgDkHfOIfUtUVH7OXO+j7BU4v/At5s61N5ZX6shvgPwluhsA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-sign-functions/-/postcss-sign-functions-1.1.1.tgz",
+      "integrity": "sha512-MslYkZCeMQDxetNkfmmQYgKCy4c+w9pPDfgOBCJOo/RI1RveEUdZQYtOfrC6cIZB7sD7/PHr2VGOcMXlZawrnA==",
       "funding": [
         {
           "type": "github",
@@ -3076,7 +2921,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.0",
+        "@csstools/css-calc": "^2.1.1",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3"
       },
@@ -3088,9 +2933,9 @@
       }
     },
     "node_modules/@csstools/postcss-stepped-value-functions": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-stepped-value-functions/-/postcss-stepped-value-functions-4.0.5.tgz",
-      "integrity": "sha512-G6SJ6hZJkhxo6UZojVlLo14MohH4J5J7z8CRBrxxUYy9JuZiIqUo5TBYyDGcE0PLdzpg63a7mHSJz3VD+gMwqw==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-stepped-value-functions/-/postcss-stepped-value-functions-4.0.6.tgz",
+      "integrity": "sha512-/dwlO9w8vfKgiADxpxUbZOWlL5zKoRIsCymYoh1IPuBsXODKanKnfuZRr32DEqT0//3Av1VjfNZU9yhxtEfIeA==",
       "funding": [
         {
           "type": "github",
@@ -3103,7 +2948,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.0",
+        "@csstools/css-calc": "^2.1.1",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3"
       },
@@ -3141,9 +2986,9 @@
       }
     },
     "node_modules/@csstools/postcss-trigonometric-functions": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-trigonometric-functions/-/postcss-trigonometric-functions-4.0.5.tgz",
-      "integrity": "sha512-/YQThYkt5MLvAmVu7zxjhceCYlKrYddK6LEmK5I4ojlS6BmO9u2yO4+xjXzu2+NPYmHSTtP4NFSamBCMmJ1NJA==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-trigonometric-functions/-/postcss-trigonometric-functions-4.0.6.tgz",
+      "integrity": "sha512-c4Y1D2Why/PeccaSouXnTt6WcNHJkoJRidV2VW9s5gJ97cNxnLgQ4Qj8qOqkIR9VmTQKJyNcbF4hy79ZQnWD7A==",
       "funding": [
         {
           "type": "github",
@@ -3156,7 +3001,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.0",
+        "@csstools/css-calc": "^2.1.1",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3"
       },
@@ -3221,21 +3066,21 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.0.tgz",
-      "integrity": "sha512-pieeipSOW4sQ0+bE5UFC51AOZp9NGxg89wAlZ1BAQFaiRAGK1IKUaPQ0UGZeNctJXyqZ1UvBtOQh2HH+U5GtmA==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.3.tgz",
+      "integrity": "sha512-1nELpMV40JDLJ6rpVVFX48R1jsBFIQ6RnEQDsLFGmzOjPWTOMlZqUcXcvRx8VmYV/TqnS1l784Ofz+ZEb+wEOQ==",
       "license": "MIT"
     },
     "node_modules/@docsearch/react": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.0.tgz",
-      "integrity": "sha512-WnFK720+iwTVt94CxY3u+FgX6exb3BfN5kE9xUY6uuAH/9W/UFboBZFLlrw/zxFRHoHZCOXRtOylsXF+6LHI+Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.3.tgz",
+      "integrity": "sha512-6UNrg88K7lJWmuS6zFPL/xgL+n326qXqZ7Ybyy4E8P/6Rcblk3GE8RXxeol4Pd5pFpKMhOhBhzABKKwHtbJCIg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-core": "1.17.7",
-        "@algolia/autocomplete-preset-algolia": "1.17.7",
-        "@docsearch/css": "3.8.0",
-        "algoliasearch": "^5.12.0"
+        "@algolia/autocomplete-core": "1.17.9",
+        "@algolia/autocomplete-preset-algolia": "1.17.9",
+        "@docsearch/css": "3.8.3",
+        "algoliasearch": "^5.14.2"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 19.0.0",
@@ -3258,79 +3103,10 @@
         }
       }
     },
-    "node_modules/@docsearch/react/node_modules/@algolia/client-analytics": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.17.1.tgz",
-      "integrity": "sha512-WKpGC+cUhmdm3wndIlTh8RJXoVabUH+4HrvZHC4hXtvCYojEXYeep8RZstatwSZ7Ocg6Y2u67bLw90NEINuYEw==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.17.1",
-        "@algolia/requester-browser-xhr": "5.17.1",
-        "@algolia/requester-fetch": "5.17.1",
-        "@algolia/requester-node-http": "5.17.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@docsearch/react/node_modules/@algolia/client-personalization": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.17.1.tgz",
-      "integrity": "sha512-JuNlZe1SdW9KbV0gcgdsiVkFfXt0mmPassdS3cBSGvZGbPB9JsHthD719k5Y6YOY4dGvw1JmC1i9CwCQHAS8hg==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.17.1",
-        "@algolia/requester-browser-xhr": "5.17.1",
-        "@algolia/requester-fetch": "5.17.1",
-        "@algolia/requester-node-http": "5.17.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@docsearch/react/node_modules/@algolia/recommend": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.17.1.tgz",
-      "integrity": "sha512-2992tTHkRe18qmf5SP57N78kN1D3e5t4PO1rt10sJncWtXBZWiNOK6K/UcvWsFbNSGAogFcIcvIMAl5mNp6RWA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.17.1",
-        "@algolia/requester-browser-xhr": "5.17.1",
-        "@algolia/requester-fetch": "5.17.1",
-        "@algolia/requester-node-http": "5.17.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@docsearch/react/node_modules/algoliasearch": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.17.1.tgz",
-      "integrity": "sha512-3CcbT5yTWJDIcBe9ZHgsPi184SkT1kyZi3GWlQU5EFgvq1V73X2sqHRkPCQMe0RA/uvZbB+1sFeAk73eWygeLg==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-abtesting": "5.17.1",
-        "@algolia/client-analytics": "5.17.1",
-        "@algolia/client-common": "5.17.1",
-        "@algolia/client-insights": "5.17.1",
-        "@algolia/client-personalization": "5.17.1",
-        "@algolia/client-query-suggestions": "5.17.1",
-        "@algolia/client-search": "5.17.1",
-        "@algolia/ingestion": "1.17.1",
-        "@algolia/monitoring": "1.17.1",
-        "@algolia/recommend": "5.17.1",
-        "@algolia/requester-browser-xhr": "5.17.1",
-        "@algolia/requester-fetch": "5.17.1",
-        "@algolia/requester-node-http": "5.17.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
     "node_modules/@docusaurus/babel": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.6.3.tgz",
-      "integrity": "sha512-7dW9Hat9EHYCVicFXYA4hjxBY38+hPuCURL8oRF9fySRm7vzNWuEOghA1TXcykuXZp0HLG2td4RhDxCvGG7tNw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.7.0.tgz",
+      "integrity": "sha512-0H5uoJLm14S/oKV3Keihxvh8RV+vrid+6Gv+2qhuzbqHanawga8tYnsdpjEyt36ucJjqlby2/Md2ObWjA02UXQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
@@ -3343,8 +3119,8 @@
         "@babel/runtime": "^7.25.9",
         "@babel/runtime-corejs3": "^7.25.9",
         "@babel/traverse": "^7.25.9",
-        "@docusaurus/logger": "3.6.3",
-        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -3354,17 +3130,17 @@
       }
     },
     "node_modules/@docusaurus/bundler": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.6.3.tgz",
-      "integrity": "sha512-47JLuc8D4wA+6VOvmMd5fUC9rFppBQpQOnxDYiVXffm/DeV/wmm3sbpNd5Y+O+G2+nevLTRnvCm/qyancv0Y3A==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.7.0.tgz",
+      "integrity": "sha512-CUUT9VlSGukrCU5ctZucykvgCISivct+cby28wJwCC/fkQFgAHRp/GKv2tx38ZmXb7nacrKzFTcp++f9txUYGg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
-        "@docusaurus/babel": "3.6.3",
-        "@docusaurus/cssnano-preset": "3.6.3",
-        "@docusaurus/logger": "3.6.3",
-        "@docusaurus/types": "3.6.3",
-        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/babel": "3.7.0",
+        "@docusaurus/cssnano-preset": "3.7.0",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/types": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
         "babel-loader": "^9.2.1",
         "clean-css": "^5.3.2",
         "copy-webpack-plugin": "^11.0.0",
@@ -3398,18 +3174,18 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.3.tgz",
-      "integrity": "sha512-xL7FRY9Jr5DWqB6pEnqgKqcMPJOX5V0pgWXi5lCiih11sUBmcFKM7c3+GyxcVeeWFxyYSDP3grLTWqJoP4P9Vw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
+      "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.6.3",
-        "@docusaurus/bundler": "3.6.3",
-        "@docusaurus/logger": "3.6.3",
-        "@docusaurus/mdx-loader": "3.6.3",
-        "@docusaurus/utils": "3.6.3",
-        "@docusaurus/utils-common": "3.6.3",
-        "@docusaurus/utils-validation": "3.6.3",
+        "@docusaurus/babel": "3.7.0",
+        "@docusaurus/bundler": "3.7.0",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/mdx-loader": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-common": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -3430,13 +3206,12 @@
         "p-map": "^4.0.0",
         "prompts": "^2.4.2",
         "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
         "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
         "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
         "react-router": "^5.3.4",
         "react-router-config": "^5.1.1",
         "react-router-dom": "^5.3.4",
-        "rtl-detect": "^1.0.4",
         "semver": "^7.5.4",
         "serve-handler": "^6.1.6",
         "shelljs": "^0.8.5",
@@ -3455,14 +3230,14 @@
       },
       "peerDependencies": {
         "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.6.3.tgz",
-      "integrity": "sha512-qP7SXrwZ+23GFJdPN4aIHQrZW+oH/7tzwEuc/RNL0+BdZdmIjYQqUxdXsjE4lFxLNZjj0eUrSNYIS6xwfij+5Q==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.7.0.tgz",
+      "integrity": "sha512-X9GYgruZBSOozg4w4dzv9uOz8oK/EpPVQXkp0MM6Tsgp/nRIU9hJzJ0Pxg1aRa3xCeEQTOimZHcocQFlLwYajQ==",
       "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
@@ -3475,9 +3250,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.6.3.tgz",
-      "integrity": "sha512-xSubJixcNyMV9wMV4q0s47CBz3Rlc5jbcCCuij8pfQP8qn/DIpt0ks8W6hQWzHAedg/J/EwxxUOUrnEoKzJo8g==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
+      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -3488,14 +3263,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.6.3.tgz",
-      "integrity": "sha512-3iJdiDz9540ppBseeI93tWTDtUGVkxzh59nMq4ignylxMuXBLK8dFqVeaEor23v1vx6TrGKZ2FuLaTB+U7C0QQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
+      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.6.3",
-        "@docusaurus/utils": "3.6.3",
-        "@docusaurus/utils-validation": "3.6.3",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -3522,22 +3297,22 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.6.3.tgz",
-      "integrity": "sha512-MjaXX9PN/k5ugNvfRZdWyKWq4FsrhN4LEXaj0pEmMebJuBNlFeGyKQUa9DRhJHpadNaiMLrbo9m3U7Ig5YlsZg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.7.0.tgz",
+      "integrity": "sha512-g7WdPqDNaqA60CmBrr0cORTrsOit77hbsTj7xE2l71YhBn79sxdm7WMK7wfhcaafkbpIh7jv5ef5TOpf1Xv9Lg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.6.3",
+        "@docusaurus/types": "3.7.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
         "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@*",
         "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
       },
       "peerDependencies": {
@@ -3546,19 +3321,19 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.6.3.tgz",
-      "integrity": "sha512-k0ogWwwJU3pFRFfvW1kRVHxzf2DutLGaaLjAnHVEU6ju+aRP0Z5ap/13DHyPOfHeE4WKpn/M0TqjdwZAcY3kAw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.7.0.tgz",
+      "integrity": "sha512-EFLgEz6tGHYWdPU0rK8tSscZwx+AsyuBW/r+tNig2kbccHYGUJmZtYN38GjAa3Fda4NU+6wqUO5kTXQSRBQD3g==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.3",
-        "@docusaurus/logger": "3.6.3",
-        "@docusaurus/mdx-loader": "3.6.3",
-        "@docusaurus/theme-common": "3.6.3",
-        "@docusaurus/types": "3.6.3",
-        "@docusaurus/utils": "3.6.3",
-        "@docusaurus/utils-common": "3.6.3",
-        "@docusaurus/utils-validation": "3.6.3",
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/mdx-loader": "3.7.0",
+        "@docusaurus/theme-common": "3.7.0",
+        "@docusaurus/types": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-common": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
         "cheerio": "1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -3575,25 +3350,25 @@
       },
       "peerDependencies": {
         "@docusaurus/plugin-content-docs": "*",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.6.3.tgz",
-      "integrity": "sha512-r2wS8y/fsaDcxkm20W5bbYJFPzdWdEaTWVYjNxlHlcmX086eqQR1Fomlg9BHTJ0dLXPzAlbC8EN4XqMr3QzNCQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.7.0.tgz",
+      "integrity": "sha512-GXg5V7kC9FZE4FkUZA8oo/NrlRb06UwuICzI6tcbzj0+TVgjq/mpUXXzSgKzMS82YByi4dY2Q808njcBCyy6tQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.3",
-        "@docusaurus/logger": "3.6.3",
-        "@docusaurus/mdx-loader": "3.6.3",
-        "@docusaurus/module-type-aliases": "3.6.3",
-        "@docusaurus/theme-common": "3.6.3",
-        "@docusaurus/types": "3.6.3",
-        "@docusaurus/utils": "3.6.3",
-        "@docusaurus/utils-common": "3.6.3",
-        "@docusaurus/utils-validation": "3.6.3",
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/mdx-loader": "3.7.0",
+        "@docusaurus/module-type-aliases": "3.7.0",
+        "@docusaurus/theme-common": "3.7.0",
+        "@docusaurus/types": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-common": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -3607,21 +3382,21 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.6.3.tgz",
-      "integrity": "sha512-eHrmTgjgLZsuqfsYr5X2xEwyIcck0wseSofWrjTwT9FLOWp+KDmMAuVK+wRo7sFImWXZk3oV/xX/g9aZrhD7OA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.7.0.tgz",
+      "integrity": "sha512-YJSU3tjIJf032/Aeao8SZjFOrXJbz/FACMveSMjLyMH4itQyZ2XgUIzt4y+1ISvvk5zrW4DABVT2awTCqBkx0Q==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.3",
-        "@docusaurus/mdx-loader": "3.6.3",
-        "@docusaurus/types": "3.6.3",
-        "@docusaurus/utils": "3.6.3",
-        "@docusaurus/utils-validation": "3.6.3",
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/mdx-loader": "3.7.0",
+        "@docusaurus/types": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -3630,19 +3405,19 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.6.3.tgz",
-      "integrity": "sha512-zB9GXfIZNPRfzKnNjU6xGVrqn9bPXuGhpjgsuc/YtcTDjnjhasg38NdYd5LEqXex5G/zIorQgWB3n6x/Ut62vQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.7.0.tgz",
+      "integrity": "sha512-Qgg+IjG/z4svtbCNyTocjIwvNTNEwgRjSXXSJkKVG0oWoH0eX/HAPiu+TS1HBwRPQV+tTYPWLrUypYFepfujZA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.3",
-        "@docusaurus/types": "3.6.3",
-        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/types": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
@@ -3651,38 +3426,38 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.6.3.tgz",
-      "integrity": "sha512-rCDNy1QW8Dag7nZq67pcum0bpFLrwvxJhYuVprhFh8BMBDxV0bY+bAkGHbSf68P3Bk9C3hNOAXX1srGLIDvcTA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.7.0.tgz",
+      "integrity": "sha512-otIqiRV/jka6Snjf+AqB360XCeSv7lQC+DKYW+EUZf6XbuE8utz5PeUQ8VuOcD8Bk5zvT1MC4JKcd5zPfDuMWA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.3",
-        "@docusaurus/types": "3.6.3",
-        "@docusaurus/utils-validation": "3.6.3",
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/types": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
         "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.6.3.tgz",
-      "integrity": "sha512-+OyDvhM6rqVkQOmLVkQWVJAizEEfkPzVWtIHXlWPOCFGK9X4/AWeBSrU0WG4iMg9Z4zD4YDRrU+lvI4s6DSC+w==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.7.0.tgz",
+      "integrity": "sha512-M3vrMct1tY65ModbyeDaMoA+fNJTSPe5qmchhAbtqhDD/iALri0g9LrEpIOwNaoLmm6lO88sfBUADQrSRSGSWA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.3",
-        "@docusaurus/types": "3.6.3",
-        "@docusaurus/utils-validation": "3.6.3",
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/types": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -3690,41 +3465,41 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.6.3.tgz",
-      "integrity": "sha512-1M6UPB13gWUtN2UHX083/beTn85PlRI9ABItTl/JL1FJ5dJTWWFXXsHf9WW/6hrVwthwTeV/AGbGKvLKV+IlCA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.7.0.tgz",
+      "integrity": "sha512-X8U78nb8eiMiPNg3jb9zDIVuuo/rE1LjGDGu+5m5CX4UBZzjMy+klOY2fNya6x8ACyE/L3K2erO1ErheP55W/w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.3",
-        "@docusaurus/types": "3.6.3",
-        "@docusaurus/utils-validation": "3.6.3",
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/types": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
         "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.6.3.tgz",
-      "integrity": "sha512-94qOO4M9Fwv9KfVQJsgbe91k+fPJ4byf1L3Ez8TUa6TAFPo/BrLwQ80zclHkENlL1824TuxkcMKv33u6eydQCg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.7.0.tgz",
+      "integrity": "sha512-bTRT9YLZ/8I/wYWKMQke18+PF9MV8Qub34Sku6aw/vlZ/U+kuEuRpQ8bTcNOjaTSfYsWkK4tTwDMHK2p5S86cA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.3",
-        "@docusaurus/logger": "3.6.3",
-        "@docusaurus/types": "3.6.3",
-        "@docusaurus/utils": "3.6.3",
-        "@docusaurus/utils-common": "3.6.3",
-        "@docusaurus/utils-validation": "3.6.3",
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/types": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-common": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -3733,57 +3508,81 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.6.3.tgz",
-      "integrity": "sha512-VHSYWROT3flvNNI1SrnMOtW1EsjeHNK9dhU6s9eY5hryZe79lUqnZJyze/ymDe2LXAqzyj6y5oYvyBoZZk6ErA==",
+    "node_modules/@docusaurus/plugin-svgr": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.7.0.tgz",
+      "integrity": "sha512-HByXIZTbc4GV5VAUkZ2DXtXv1Qdlnpk3IpuImwSnEzCDBkUMYcec5282hPjn6skZqB25M1TYCmWS91UbhBGxQg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.3",
-        "@docusaurus/plugin-content-blog": "3.6.3",
-        "@docusaurus/plugin-content-docs": "3.6.3",
-        "@docusaurus/plugin-content-pages": "3.6.3",
-        "@docusaurus/plugin-debug": "3.6.3",
-        "@docusaurus/plugin-google-analytics": "3.6.3",
-        "@docusaurus/plugin-google-gtag": "3.6.3",
-        "@docusaurus/plugin-google-tag-manager": "3.6.3",
-        "@docusaurus/plugin-sitemap": "3.6.3",
-        "@docusaurus/theme-classic": "3.6.3",
-        "@docusaurus/theme-common": "3.6.3",
-        "@docusaurus/theme-search-algolia": "3.6.3",
-        "@docusaurus/types": "3.6.3"
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/types": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
+        "@svgr/core": "8.1.0",
+        "@svgr/webpack": "^8.1.0",
+        "tslib": "^2.6.0",
+        "webpack": "^5.88.1"
       },
       "engines": {
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.7.0.tgz",
+      "integrity": "sha512-nPHj8AxDLAaQXs+O6+BwILFuhiWbjfQWrdw2tifOClQoNfuXDjfjogee6zfx6NGHWqshR23LrcN115DmkHC91Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/plugin-content-blog": "3.7.0",
+        "@docusaurus/plugin-content-docs": "3.7.0",
+        "@docusaurus/plugin-content-pages": "3.7.0",
+        "@docusaurus/plugin-debug": "3.7.0",
+        "@docusaurus/plugin-google-analytics": "3.7.0",
+        "@docusaurus/plugin-google-gtag": "3.7.0",
+        "@docusaurus/plugin-google-tag-manager": "3.7.0",
+        "@docusaurus/plugin-sitemap": "3.7.0",
+        "@docusaurus/plugin-svgr": "3.7.0",
+        "@docusaurus/theme-classic": "3.7.0",
+        "@docusaurus/theme-common": "3.7.0",
+        "@docusaurus/theme-search-algolia": "3.7.0",
+        "@docusaurus/types": "3.7.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.6.3.tgz",
-      "integrity": "sha512-1RRLK1tSArI2c00qugWYO3jRocjOZwGF1mBzPPylDVRwWCS/rnWWR91ChdbbaxIupRJ+hX8ZBYrwr5bbU0oztQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.7.0.tgz",
+      "integrity": "sha512-MnLxG39WcvLCl4eUzHr0gNcpHQfWoGqzADCly54aqCofQX6UozOS9Th4RK3ARbM9m7zIRv3qbhggI53dQtx/hQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.3",
-        "@docusaurus/logger": "3.6.3",
-        "@docusaurus/mdx-loader": "3.6.3",
-        "@docusaurus/module-type-aliases": "3.6.3",
-        "@docusaurus/plugin-content-blog": "3.6.3",
-        "@docusaurus/plugin-content-docs": "3.6.3",
-        "@docusaurus/plugin-content-pages": "3.6.3",
-        "@docusaurus/theme-common": "3.6.3",
-        "@docusaurus/theme-translations": "3.6.3",
-        "@docusaurus/types": "3.6.3",
-        "@docusaurus/utils": "3.6.3",
-        "@docusaurus/utils-common": "3.6.3",
-        "@docusaurus/utils-validation": "3.6.3",
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/mdx-loader": "3.7.0",
+        "@docusaurus/module-type-aliases": "3.7.0",
+        "@docusaurus/plugin-content-blog": "3.7.0",
+        "@docusaurus/plugin-content-docs": "3.7.0",
+        "@docusaurus/plugin-content-pages": "3.7.0",
+        "@docusaurus/theme-common": "3.7.0",
+        "@docusaurus/theme-translations": "3.7.0",
+        "@docusaurus/types": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-common": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -3802,20 +3601,20 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.6.3.tgz",
-      "integrity": "sha512-b8ZkhczXHDxWWyvz+YJy4t/PlPbEogTTbgnHoflYnH7rmRtyoodTsu8WVM12la5LmlMJBclBXFl29OH8kPE7gg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.7.0.tgz",
+      "integrity": "sha512-8eJ5X0y+gWDsURZnBfH0WabdNm8XMCXHv8ENy/3Z/oQKwaB/EHt5lP9VsTDTf36lKEp0V6DjzjFyFIB+CetL0A==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.6.3",
-        "@docusaurus/module-type-aliases": "3.6.3",
-        "@docusaurus/utils": "3.6.3",
-        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/mdx-loader": "3.7.0",
+        "@docusaurus/module-type-aliases": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-common": "3.7.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -3830,26 +3629,26 @@
       },
       "peerDependencies": {
         "@docusaurus/plugin-content-docs": "*",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.6.3.tgz",
-      "integrity": "sha512-rt+MGCCpYgPyWCGXtbxlwFbTSobu15jWBTPI2LHsHNa5B0zSmOISX6FWYAPt5X1rNDOqMGM0FATnh7TBHRohVA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.7.0.tgz",
+      "integrity": "sha512-Al/j5OdzwRU1m3falm+sYy9AaB93S1XF1Lgk9Yc6amp80dNxJVplQdQTR4cYdzkGtuQqbzUA8+kaoYYO0RbK6g==",
       "license": "MIT",
       "dependencies": {
-        "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.6.3",
-        "@docusaurus/logger": "3.6.3",
-        "@docusaurus/plugin-content-docs": "3.6.3",
-        "@docusaurus/theme-common": "3.6.3",
-        "@docusaurus/theme-translations": "3.6.3",
-        "@docusaurus/utils": "3.6.3",
-        "@docusaurus/utils-validation": "3.6.3",
-        "algoliasearch": "^4.18.0",
-        "algoliasearch-helper": "^3.13.3",
+        "@docsearch/react": "^3.8.1",
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/plugin-content-docs": "3.7.0",
+        "@docusaurus/theme-common": "3.7.0",
+        "@docusaurus/theme-translations": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
+        "algoliasearch": "^5.17.1",
+        "algoliasearch-helper": "^3.22.6",
         "clsx": "^2.0.0",
         "eta": "^2.2.0",
         "fs-extra": "^11.1.1",
@@ -3861,14 +3660,14 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.6.3.tgz",
-      "integrity": "sha512-Gb0regclToVlngSIIwUCtBMQBq48qVUaN1XQNKW4XwlsgUyk0vP01LULdqbem7czSwIeBAFXFoORJ0RPX7ht/w==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.7.0.tgz",
+      "integrity": "sha512-Ewq3bEraWDmienM6eaNK7fx+/lHMtGDHQyd1O+4+3EsDxxUmrzPkV7Ct3nBWTuE0MsoZr3yNwQVKjllzCMuU3g==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
@@ -3879,9 +3678,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.6.3.tgz",
-      "integrity": "sha512-xD9oTGDrouWzefkhe9ogB2fDV96/82cRpNGx2HIvI5L87JHNhQVIWimQ/3JIiiX/TEd5S9s+VO6FFguwKNRVow==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.7.0.tgz",
+      "integrity": "sha512-kOmZg5RRqJfH31m+6ZpnwVbkqMJrPOG5t0IOl4i/+3ruXyNfWzZ0lVtVrD0u4ONc/0NOsS9sWYaxxWNkH1LdLQ==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -3889,14 +3688,14 @@
         "@types/react": "*",
         "commander": "^5.1.0",
         "joi": "^17.9.2",
-        "react-helmet-async": "^1.3.0",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
         "utility-types": "^3.10.0",
         "webpack": "^5.95.0",
         "webpack-merge": "^5.9.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/types/node_modules/webpack-merge": {
@@ -3914,15 +3713,14 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.6.3.tgz",
-      "integrity": "sha512-0R/FR3bKVl4yl8QwbL4TYFfR+OXBRpVUaTJdENapBGR3YMwfM6/JnhGilWQO8AOwPJGtGoDK7ib8+8UF9f3OZQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
+      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.6.3",
-        "@docusaurus/types": "3.6.3",
-        "@docusaurus/utils-common": "3.6.3",
-        "@svgr/webpack": "^8.1.0",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/types": "3.7.0",
+        "@docusaurus/utils-common": "3.7.0",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
@@ -3946,12 +3744,12 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.6.3.tgz",
-      "integrity": "sha512-v4nKDaANLgT3pMBewHYEMAl/ufY0LkXao1QkFWzI5huWFOmNQ2UFzv2BiKeHX5Ownis0/w6cAyoxPhVdDonlSQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
+      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.6.3",
+        "@docusaurus/types": "3.7.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3959,14 +3757,14 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.6.3.tgz",
-      "integrity": "sha512-bhEGGiN5BE38h21vjqD70Gxg++j+PfYVddDUE5UFvLDup68QOcpD33CLr+2knPorlxRbEaNfz6HQDUMQ3HuqKw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
+      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.6.3",
-        "@docusaurus/utils": "3.6.3",
-        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-common": "3.7.0",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -4652,9 +4450,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.2.tgz",
-      "integrity": "sha512-vluaspfvWEtE4vcSDlKRNer52DvOGrB2xv6diXy6UKyKW0lqZiWHGNApSyxOv+8DE5Z27IzVvE7hNkxg7EXIcg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
+      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -4775,15 +4573,15 @@
       "license": "MIT"
     },
     "node_modules/@types/ms": {
-      "version": "0.7.34",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
-      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "version": "22.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
+      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
@@ -4823,9 +4621,9 @@
       "license": "MIT"
     },
     "node_modules/@types/qs": {
-      "version": "6.9.17",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.17.tgz",
-      "integrity": "sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==",
+      "version": "6.9.18",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
@@ -4835,9 +4633,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.16",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.16.tgz",
-      "integrity": "sha512-oh8AMIC4Y2ciKufU8hnKgs+ufgbA/dhPTACaZPM86AbwX9QwnFtSoPWEeRUj8fge+v6kFt78BXcDhAU1SrrAsw==",
+      "version": "18.3.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
+      "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4937,9 +4735,9 @@
       "license": "MIT"
     },
     "node_modules/@types/ws": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
-      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.14.tgz",
+      "integrity": "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -4961,9 +4759,9 @@
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
-      "integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
     "node_modules/@webassemblyjs/ast": {
@@ -5274,77 +5072,39 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.24.0.tgz",
-      "integrity": "sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.20.0.tgz",
+      "integrity": "sha512-groO71Fvi5SWpxjI9Ia+chy0QBwT61mg6yxJV27f5YFf+Mw+STT75K6SHySpP8Co5LsCrtsbCH5dJZSRtkSKaQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.24.0",
-        "@algolia/cache-common": "4.24.0",
-        "@algolia/cache-in-memory": "4.24.0",
-        "@algolia/client-account": "4.24.0",
-        "@algolia/client-analytics": "4.24.0",
-        "@algolia/client-common": "4.24.0",
-        "@algolia/client-personalization": "4.24.0",
-        "@algolia/client-search": "4.24.0",
-        "@algolia/logger-common": "4.24.0",
-        "@algolia/logger-console": "4.24.0",
-        "@algolia/recommend": "4.24.0",
-        "@algolia/requester-browser-xhr": "4.24.0",
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/requester-node-http": "4.24.0",
-        "@algolia/transporter": "4.24.0"
+        "@algolia/client-abtesting": "5.20.0",
+        "@algolia/client-analytics": "5.20.0",
+        "@algolia/client-common": "5.20.0",
+        "@algolia/client-insights": "5.20.0",
+        "@algolia/client-personalization": "5.20.0",
+        "@algolia/client-query-suggestions": "5.20.0",
+        "@algolia/client-search": "5.20.0",
+        "@algolia/ingestion": "1.20.0",
+        "@algolia/monitoring": "1.20.0",
+        "@algolia/recommend": "5.20.0",
+        "@algolia/requester-browser-xhr": "5.20.0",
+        "@algolia/requester-fetch": "5.20.0",
+        "@algolia/requester-node-http": "5.20.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.22.6",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.22.6.tgz",
-      "integrity": "sha512-F2gSb43QHyvZmvH/2hxIjbk/uFdO2MguQYTFP7J+RowMW1csjIODMobEnpLI8nbLQuzZnGZdIxl5Bpy1k9+CFQ==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.24.1.tgz",
+      "integrity": "sha512-knYRACqLH9UpeR+WRUrBzBFR2ulGuOjI2b525k4PNeqZxeFMHJE7YcL7s6Jh12Qza0rtHqZdgHMfeuaaAkf4wA==",
       "license": "MIT",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
       "peerDependencies": {
         "algoliasearch": ">= 3.1 < 6"
-      }
-    },
-    "node_modules/algoliasearch/node_modules/@algolia/client-common": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
-      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/transporter": "4.24.0"
-      }
-    },
-    "node_modules/algoliasearch/node_modules/@algolia/client-search": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
-      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "4.24.0",
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/transporter": "4.24.0"
-      }
-    },
-    "node_modules/algoliasearch/node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
-      "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.24.0"
-      }
-    },
-    "node_modules/algoliasearch/node_modules/@algolia/requester-node-http": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
-      "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/ansi-align": {
@@ -5785,9 +5545,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
-      "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "funding": [
         {
           "type": "opencollective",
@@ -5890,13 +5650,13 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.2.tgz",
-      "integrity": "sha512-0lk0PHFe/uz0vl527fG9CgdE9WdafjDbCXvBbs+LUv000TVt2Jjhqbs4Jwm8gz070w8xXyEAxrPOMullsxXeGg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "get-intrinsic": "^1.2.5"
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5949,9 +5709,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001688",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001688.tgz",
-      "integrity": "sha512-Nmqpru91cuABu/DTCXbM2NSRHzM2uVHfPnhJ/1zEAJx/ILBRVmz3pzH4N7DZqbdG0gWClsCC05Oj0mJ/1AWMbA==",
+      "version": "1.0.30001697",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
+      "integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6420,9 +6180,9 @@
       }
     },
     "node_modules/consola": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
-      "integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
+      "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -6553,9 +6313,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.39.0.tgz",
-      "integrity": "sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.40.0.tgz",
+      "integrity": "sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -6564,12 +6324,12 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.39.0.tgz",
-      "integrity": "sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.40.0.tgz",
+      "integrity": "sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==",
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.24.2"
+        "browserslist": "^4.24.3"
       },
       "funding": {
         "type": "opencollective",
@@ -6577,9 +6337,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.39.0.tgz",
-      "integrity": "sha512-7fEcWwKI4rJinnK+wLTezeg2smbFFdSBP6E2kQZNbnzM2s1rpKQ6aaRteZSSg7FLU3P0HGGVo/gbpfanU36urg==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.40.0.tgz",
+      "integrity": "sha512-AtDzVIgRrmRKQai62yuSIN5vNiQjcJakJb4fbhVw3ehxx7Lohphvw9SGNWKhLFqSxC4ilD0g/L1huAYFQU3Q6A==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -7385,33 +7145,33 @@
       }
     },
     "node_modules/docusaurus-lunr-search": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/docusaurus-lunr-search/-/docusaurus-lunr-search-3.5.0.tgz",
-      "integrity": "sha512-k3zN4jYMi/prWInJILGKOxE+BVcgYinwj9+gcECsYm52tS+4ZKzXQzbPnVJAEXmvKOfFMcDFvS3MSmm6cEaxIQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/docusaurus-lunr-search/-/docusaurus-lunr-search-3.6.0.tgz",
+      "integrity": "sha512-CCEAnj5e67sUZmIb2hOl4xb4nDN07fb0fvRDDmdWlYpUvyS1CSKbw4lsGInLyUFEEEBzxQmT6zaVQdF/8Zretg==",
       "license": "MIT",
       "dependencies": {
-        "autocomplete.js": "^0.37.0",
-        "clsx": "^1.2.1",
-        "gauge": "^3.0.0",
-        "hast-util-select": "^4.0.0",
-        "hast-util-to-text": "^2.0.0",
+        "autocomplete.js": "^0.37.1",
+        "clsx": "^2.1.1",
+        "gauge": "^3.0.2",
+        "hast-util-select": "^4.0.2",
+        "hast-util-to-text": "^2.0.1",
         "hogan.js": "^3.0.2",
-        "lunr": "^2.3.8",
+        "lunr": "^2.3.9",
         "lunr-languages": "^1.4.0",
         "mark.js": "^8.11.1",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "rehype-parse": "^7.0.1",
         "to-vfile": "^6.1.0",
-        "unified": "^9.0.0",
-        "unist-util-is": "^4.0.2"
+        "unified": "^9.2.2",
+        "unist-util-is": "^4.1.0"
       },
       "engines": {
         "node": ">= 8.10.0"
       },
       "peerDependencies": {
         "@docusaurus/core": "^2.0.0-alpha.60 || ^2.0.0 || ^3.0.0",
-        "react": "^16.8.4 || ^17 || ^18",
-        "react-dom": "^16.8.4 || ^17 || ^18"
+        "react": "^16.8.4 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8.4 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/docusaurus-lunr-search/node_modules/@types/unist": {
@@ -7428,15 +7188,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/docusaurus-lunr-search/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/docusaurus-lunr-search/node_modules/is-plain-obj": {
@@ -7570,9 +7321,9 @@
       }
     },
     "node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
@@ -7618,12 +7369,12 @@
       }
     },
     "node_modules/dunder-proto": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.0.tgz",
-      "integrity": "sha512-9+Sj30DIu+4KvHqMfLUGLFYL2PkURSYMVXJyXe92nFRvlYq5hBjLEhblKB+vkd/WVlUYMWigiY07T91Fkk0+4A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
         "gopd": "^1.2.0"
       },
@@ -7650,9 +7401,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.73",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.73.tgz",
-      "integrity": "sha512-8wGNxG9tAG5KhGd3eeA0o6ixhiNdgr0DcHWm85XPCphwZgD1lIEoi6t3VERayWao7SF7AAZTw6oARGJeVjH8Kg==",
+      "version": "1.5.92",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.92.tgz",
+      "integrity": "sha512-BeHgmNobs05N1HMmMZ7YIuHfYBGlq/UmvlsTgg+fsbFs9xVMj+xJHFg19GN04+9Q+r8Xnh9LXqaYIyEWElnNgQ==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -7696,9 +7447,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -7748,15 +7499,15 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
-      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7961,9 +7712,9 @@
       }
     },
     "node_modules/estree-util-value-to-estree": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.2.1.tgz",
-      "integrity": "sha512-Vt2UOjyPbNQQgT5eJh+K5aATti0OjCIAGc9SgMdOFYbohuifsWclR74l0iZTJwePMgWYdX1hlVS+dedH9XV8kw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.3.2.tgz",
+      "integrity": "sha512-hYH1aSvQI63Cvq3T3loaem6LW4u72F187zW4FHpTrReJSm6W66vYTFNO1vH/chmcOulp1HlAj1pxn8Ag0oXI5Q==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -8188,16 +7939,16 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -8210,15 +7961,25 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
-      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
+      "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -8646,9 +8407,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -8745,21 +8506,21 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
-      "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
-        "dunder-proto": "^1.0.0",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
+        "get-proto": "^1.0.0",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
-        "math-intrinsics": "^1.0.0"
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8773,6 +8534,19 @@
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
       "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
       "license": "ISC"
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
@@ -9396,9 +9170,9 @@
       }
     },
     "node_modules/hast-util-to-estree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.0.tgz",
-      "integrity": "sha512-lfX5g6hqVh9kjS/B9E2gSkvHH4SZNiQFiqWS0x9fENzEl+8W12RqdRxX6d/Cwxi30tPQs3bIO+aolQJNp1bIyw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.1.tgz",
+      "integrity": "sha512-IWtwwmPskfSmma9RpzCappDUitC8t5jhAynHhc1m2+5trOgsrp7txscUSavc5Ic8PATyAjfrCK1wgtxh2cICVQ==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -9414,7 +9188,7 @@
         "mdast-util-mdxjs-esm": "^2.0.0",
         "property-information": "^6.0.0",
         "space-separated-tokens": "^2.0.0",
-        "style-to-object": "^0.4.0",
+        "style-to-object": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "zwitch": "^2.0.0"
       },
@@ -9446,12 +9220,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-to-estree/node_modules/inline-style-parser": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
-      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
-      "license": "MIT"
-    },
     "node_modules/hast-util-to-estree/node_modules/property-information": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
@@ -9470,15 +9238,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/hast-util-to-estree/node_modules/style-to-object": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
-      "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
-      "license": "MIT",
-      "dependencies": {
-        "inline-style-parser": "0.1.1"
       }
     },
     "node_modules/hast-util-to-estree/node_modules/zwitch": {
@@ -9973,9 +9732,9 @@
       }
     },
     "node_modules/http-parser-js": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
-      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.9.tgz",
+      "integrity": "sha512-n1XsPy3rXVxlqxVioEWdC+0+M+SQw0DpJynwtOPo1X+ZlvdzTLtDBIJJlDQTnwZIFJrZSzSGmIOUdP8tu+SgLw==",
       "license": "MIT"
     },
     "node_modules/http-proxy": {
@@ -10084,9 +9843,9 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.1.1.tgz",
-      "integrity": "sha512-541xKlUw6jr/6gGuk92F+mYM5zaFAc5ahphvkqvNe2bQ6gVBkd6bfrmVJ2t4KDAfikAYZyIqTnktX3i6/aQDrQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.0.tgz",
+      "integrity": "sha512-4S8fwbO6w3GeCVN6OPtA9I5IGKkcDMPcKndtUlpJuCwu7JLjtj7JZpwqLuyY2nrmQT3AWsCJLSKPsc2mPBSl3w==",
       "license": "MIT",
       "dependencies": {
         "queue": "6.0.2"
@@ -10115,9 +9874,9 @@
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -10300,9 +10059,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.0.tgz",
-      "integrity": "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -10602,9 +10361,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.21.6",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
-      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -10929,22 +10688,23 @@
       }
     },
     "node_modules/math-intrinsics": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.0.0.tgz",
-      "integrity": "sha512-4MqMiKP90ybymYvsut0CH2g4XWbfLtmlCkXmtmdcDCxNB+mQcu1w/1+L/VD7vi/PSv7X2JYV7SCcR+jiPXnQtA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/mdast-util-directive": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.0.0.tgz",
-      "integrity": "sha512-JUpYOqKI4mM3sZcNxmF/ox04XYFFkNwr0CFlrQIkCwbvH0xzMCqkMqAde9wRd80VAhaUrwFwKm2nxretdT1h7Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
+      "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.0.0",
@@ -10958,9 +10718,9 @@
       }
     },
     "node_modules/mdast-util-find-and-replace": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
-      "integrity": "sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -11241,9 +11001,9 @@
       }
     },
     "node_modules/mdast-util-mdx-jsx": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.1.3.tgz",
-      "integrity": "sha512-bfOjvNt+1AcbPLTFMFWY149nJz0OjmewJs3LQQ5pIyVGxP4CdOqNVJL6kTaM5c68p8q82Xv3nCyFfUnuEcH3UQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
       "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
@@ -11869,9 +11629,9 @@
       "license": "MIT"
     },
     "node_modules/micromark-extension-gfm-table": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.0.tgz",
-      "integrity": "sha512-Ub2ncQv+fwD70/l4ou27b4YzfNaCJOvyX4HxXU15m7mpYY+rjuWzsLIPZHJL253Z643RpbcP1oeIJlQ/SKW67g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -13095,9 +12855,9 @@
       "license": "MIT"
     },
     "node_modules/micromark-util-subtokenize": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.3.tgz",
-      "integrity": "sha512-VXJJuNxYWSoYL6AJ6OQECCFGhIU2GGHMw8tahogePBrjkG8aCCas3ibkp7RnVOSTClg2is05/R7maAhF1XyQMg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.4.tgz",
+      "integrity": "sha512-N6hXjrin2GTJDe3MVjf5FuXpm12PGm80BrUAeub9XFXca8JZbP+oIwY4LJSVwFUCL1IPm/WwSVUN7goFHmSGGQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -13604,9 +13364,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13625,14 +13385,16 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
-        "has-symbols": "^1.0.3",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -14092,9 +13854,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
+      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -14111,7 +13873,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -14189,9 +13951,9 @@
       }
     },
     "node_modules/postcss-color-functional-notation": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-7.0.6.tgz",
-      "integrity": "sha512-wLXvm8RmLs14Z2nVpB4CWlnvaWPRcOZFltJSlcbYwSJ1EDZKsKDhPKIMecCnuU054KSmlmubkqczmm6qBPCBhA==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-7.0.7.tgz",
+      "integrity": "sha512-EZvAHsvyASX63vXnyXOIynkxhaHRSsdb7z6yiXKIovGXAolW4cMZ3qoh7k3VdTsLBS6VGdksGfIo3r6+waLoOw==",
       "funding": [
         {
           "type": "github",
@@ -14204,7 +13966,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.6",
+        "@csstools/css-color-parser": "^3.0.7",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "@csstools/postcss-progressive-custom-properties": "^4.0.0",
@@ -14663,9 +14425,9 @@
       }
     },
     "node_modules/postcss-lab-function": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-7.0.6.tgz",
-      "integrity": "sha512-HPwvsoK7C949vBZ+eMyvH2cQeMr3UREoHvbtra76/UhDuiViZH6pir+z71UaJQohd7VDSVUdR6TkWYKExEc9aQ==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-7.0.7.tgz",
+      "integrity": "sha512-+ONj2bpOQfsCKZE2T9VGMyVVdGcGUpr7u3SVfvkJlvhTRmDCfY25k4Jc8fubB9DclAPR4+w8uVtDZmdRgdAHig==",
       "funding": [
         {
           "type": "github",
@@ -14678,7 +14440,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.6",
+        "@csstools/css-color-parser": "^3.0.7",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "@csstools/postcss-progressive-custom-properties": "^4.0.0",
@@ -15252,9 +15014,9 @@
       }
     },
     "node_modules/postcss-preset-env": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.1.2.tgz",
-      "integrity": "sha512-OqUBZ9ByVfngWhMNuBEMy52Izj07oIFA6K/EOGBlaSv+P12MiE1+S2cqXtS1VuW82demQ/Tzc7typYk3uHunkA==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.1.3.tgz",
+      "integrity": "sha512-9qzVhcMFU/MnwYHyYpJz4JhGku/4+xEiPTmhn0hj3IxnUYlEF9vbh7OC1KoLAnenS6Fgg43TKNp9xcuMeAi4Zw==",
       "funding": [
         {
           "type": "github",
@@ -15268,14 +15030,14 @@
       "license": "MIT-0",
       "dependencies": {
         "@csstools/postcss-cascade-layers": "^5.0.1",
-        "@csstools/postcss-color-function": "^4.0.6",
-        "@csstools/postcss-color-mix-function": "^3.0.6",
+        "@csstools/postcss-color-function": "^4.0.7",
+        "@csstools/postcss-color-mix-function": "^3.0.7",
         "@csstools/postcss-content-alt-text": "^2.0.4",
-        "@csstools/postcss-exponential-functions": "^2.0.5",
+        "@csstools/postcss-exponential-functions": "^2.0.6",
         "@csstools/postcss-font-format-keywords": "^4.0.0",
-        "@csstools/postcss-gamut-mapping": "^2.0.6",
-        "@csstools/postcss-gradients-interpolation-method": "^5.0.6",
-        "@csstools/postcss-hwb-function": "^4.0.6",
+        "@csstools/postcss-gamut-mapping": "^2.0.7",
+        "@csstools/postcss-gradients-interpolation-method": "^5.0.7",
+        "@csstools/postcss-hwb-function": "^4.0.7",
         "@csstools/postcss-ic-unit": "^4.0.0",
         "@csstools/postcss-initial": "^2.0.0",
         "@csstools/postcss-is-pseudo-class": "^5.0.1",
@@ -15285,19 +15047,19 @@
         "@csstools/postcss-logical-overscroll-behavior": "^2.0.0",
         "@csstools/postcss-logical-resize": "^3.0.0",
         "@csstools/postcss-logical-viewport-units": "^3.0.3",
-        "@csstools/postcss-media-minmax": "^2.0.5",
+        "@csstools/postcss-media-minmax": "^2.0.6",
         "@csstools/postcss-media-queries-aspect-ratio-number-values": "^3.0.4",
         "@csstools/postcss-nested-calc": "^4.0.0",
         "@csstools/postcss-normalize-display-values": "^4.0.0",
-        "@csstools/postcss-oklab-function": "^4.0.6",
+        "@csstools/postcss-oklab-function": "^4.0.7",
         "@csstools/postcss-progressive-custom-properties": "^4.0.0",
-        "@csstools/postcss-random-function": "^1.0.1",
-        "@csstools/postcss-relative-color-syntax": "^3.0.6",
+        "@csstools/postcss-random-function": "^1.0.2",
+        "@csstools/postcss-relative-color-syntax": "^3.0.7",
         "@csstools/postcss-scope-pseudo-class": "^4.0.1",
-        "@csstools/postcss-sign-functions": "^1.1.0",
-        "@csstools/postcss-stepped-value-functions": "^4.0.5",
+        "@csstools/postcss-sign-functions": "^1.1.1",
+        "@csstools/postcss-stepped-value-functions": "^4.0.6",
         "@csstools/postcss-text-decoration-shorthand": "^4.0.1",
-        "@csstools/postcss-trigonometric-functions": "^4.0.5",
+        "@csstools/postcss-trigonometric-functions": "^4.0.6",
         "@csstools/postcss-unset-value": "^4.0.0",
         "autoprefixer": "^10.4.19",
         "browserslist": "^4.23.1",
@@ -15307,7 +15069,7 @@
         "cssdb": "^8.2.3",
         "postcss-attribute-case-insensitive": "^7.0.1",
         "postcss-clamp": "^4.1.0",
-        "postcss-color-functional-notation": "^7.0.6",
+        "postcss-color-functional-notation": "^7.0.7",
         "postcss-color-hex-alpha": "^10.0.0",
         "postcss-color-rebeccapurple": "^10.0.0",
         "postcss-custom-media": "^11.0.5",
@@ -15320,7 +15082,7 @@
         "postcss-font-variant": "^5.0.0",
         "postcss-gap-properties": "^6.0.0",
         "postcss-image-set-function": "^7.0.0",
-        "postcss-lab-function": "^7.0.6",
+        "postcss-lab-function": "^7.0.7",
         "postcss-logical": "^8.0.0",
         "postcss-nesting": "^13.0.1",
         "postcss-opacity-percentage": "^3.0.0",
@@ -15968,9 +15730,10 @@
       "license": "MIT"
     },
     "node_modules/react-helmet-async": {
+      "name": "@slorber/react-helmet-async",
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
-      "integrity": "sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==",
+      "resolved": "https://registry.npmjs.org/@slorber/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
+      "integrity": "sha512-e9/OK8VhwUSc67diWI8Rb3I0YgI9/SBQtnhe9aEuK6MhZm7ntZZimXgwXnd8W96YTmSOb9M4d8LwhRZyhWr/1A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -15980,8 +15743,8 @@
         "shallowequal": "^1.1.0"
       },
       "peerDependencies": {
-        "react": "^16.6.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-is": {
@@ -16368,9 +16131,9 @@
       }
     },
     "node_modules/remark-directive": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.0.tgz",
-      "integrity": "sha512-l1UyWJ6Eg1VPU7Hm/9tt0zKtReJQNOA4+iDMAxTyZNWnJnFlbS/7zhiel/rogTLQ2vMYwDzSJa4BiVNqGlqIMA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.1.tgz",
+      "integrity": "sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -16628,9 +16391,9 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.9",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.9.tgz",
-      "integrity": "sha512-QxrmX1DzraFIi9PxdG5VkRfRwIgjwyud+z/iBwfRRrVmHc+P9Q7u2lSSpQ6bjr2gy5lrqIiU9vb6iAeGf2400A==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.0",
@@ -16639,6 +16402,9 @@
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -16714,12 +16480,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/rtl-detect": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
-      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/rtlcss": {
       "version": "4.3.0",
@@ -16862,9 +16622,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -17950,9 +17710,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -18188,9 +17948,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+      "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
       "funding": [
         {
           "type": "opencollective",
@@ -18208,7 +17968,7 @@
       "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
-        "picocolors": "^1.1.0"
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -18280,9 +18040,9 @@
       }
     },
     "node_modules/update-notifier/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hauler-docs",
-  "version": "1.0.x",
+  "version": "1.1.x",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -14,8 +14,8 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.6.1",
-    "@docusaurus/preset-classic": "^3.6.1",
+    "@docusaurus/core": "^3.7.0",
+    "@docusaurus/preset-classic": "^3.7.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.1.0",
     "docusaurus-lunr-search": "^3.3.2",
@@ -24,8 +24,8 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.6.1",
-    "@docusaurus/types": "^3.6.1"
+    "@docusaurus/module-type-aliases": "^3.7.0",
+    "@docusaurus/types": "^3.7.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
```bash
zackbradys@Zacks-MacBook-Pro hauler-docs % make install
npm install
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated mkdirp@0.3.0: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
npm warn deprecated gauge@3.0.2: This package is no longer supported.

added 1365 packages, and audited 1366 packages in 21s

413 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```